### PR TITLE
django-allauth removed email_address_verification method  causing a f…

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 dj-database-url
 Django>=3.2,<4
-django-allauth
+django-allauth==0.54.0
 django-cors-headers
 django-rest-auth
 django-taggit


### PR DESCRIPTION
…atal import error.

https://readthedocs.org/projects/django-allauth/downloads/pdf/latest/

look at version 0.55.0 release on aug. 22 2023 which removes the email_address_verification method.